### PR TITLE
Update idc/atmel-touchscreen.idc

### DIFF
--- a/idc/atmel-touchscreen.idc
+++ b/idc/atmel-touchscreen.idc
@@ -1,4 +1,4 @@
-# Copyright (C) 2011 The Android Open Source Project
+# Copyright (C) 2013 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,31 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Input Device Calibration File for the Tuna touch screen.
-#
+# Touch screen configuration file for HTC Vision.
+# Starting from ICS, the configuration file syntax was changed, 
+# so the new one is needed to support touch pressure and size
+# that are reported by Vision touch screen controller.
+# (c) NeverGone, January 24, 2013.
+
+# Changes:
+# Jan 24, 2013
+# -- initial commit
 
 # Basic Parameters
 touch.deviceType = touchScreen
 touch.orientationAware = 1
 
 # Size
-touch.toolSize.calibration = linear
-touch.toolSize.linearScale = 10
-touch.toolSize.linearBias = 160
-touch.toolSize.isSummed = 1
-
-touch.size.calibration = normalized
+touch.size.calibration = area
+touch.size.isSummed=0
+touch.size.scale=15
+touch.size.bias=0
 
 # Pressure
-# Driver reports signal strength as pressure.
-#
-# A normal thumb touch typically registers about 200 signal strength
-# units although we don't expect these values to be accurate.
 touch.pressure.calibration = amplitude
-touch.pressure.source = default
 touch.pressure.scale = 0.01
 
 # Orientation
 touch.orientation.calibration = none
-


### PR DESCRIPTION
It seems that nobody noticed this, but the touch screen configuration is wrong.
That leads to inablity to detect touch size and general touchscreen 'precision' is bad in some situations.
This file fixes the touch size reporting (which is actually supported by our phone).
More on touch configuration: http://source.android.com/tech/input/touch-devices.html
