### PR TITLE
Remove Noise Cancellation bool

### DIFF
--- a/overlay/packages/apps/Phone/res/values/config.xml
+++ b/overlay/packages/apps/Phone/res/values/config.xml
@@ -21,7 +21,4 @@
          so microphone muting calls should be routed through the AudioManager API. -->
     <bool name="send_mic_mute_to_AudioManager">true</bool>
 
-    <!-- This device implements a noise suppression device for in call audio-->
-    <bool name="has_in_call_noise_suppression">true</bool>
-
 </resources>


### PR DESCRIPTION
Noise Cancellation feature is not supported by Vision hardware (was supported on a prototype, but that's a different story), so this bool should be removed.
This removes Noise Cancellation option in Phone settings.
