### PR TITLE
Hide Notification speed/length settings (DO NOT MERGE)

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -224,4 +224,8 @@ Passion has no keyboard so all values are zero.
 
      <!-- Is the battery LED intrusive? Used to decide if there should be a disable option -->
      <bool name="config_intrusiveBatteryLed">true</bool>
+
+    <!-- Indicate if Notification speed/length settings should be accessible in
+         Notification Light settings. -->
+    <bool name="notification_light_onoff_visible" translatable="false">false</bool>
 </resources>


### PR DESCRIPTION
Hides notification speed/length settings, only allowing to select a color to blink.
Will be needed when this - http://review.cyanogenmod.org/#/c/33537/3 - is merged into Settings repository.
